### PR TITLE
Modified to set party_size according to the number of endpoints

### DIFF
--- a/quickmpc/qmpc.py
+++ b/quickmpc/qmpc.py
@@ -5,9 +5,10 @@ from google.protobuf.internal import enum_type_wrapper
 
 from .proto.common_types import common_types_pb2
 from .qmpc_server import QMPCServer
+from .share import Share
 from .utils.parse_csv import (parse, parse_csv, parse_csv_to_bitvector,
                               parse_to_bitvector)
-from .share import Share
+
 # qmpc.JobStatus でアクセスできるようにエイリアスを設定する
 JobStatus: enum_type_wrapper.EnumTypeWrapper \
     = common_types_pb2.JobStatus
@@ -50,9 +51,9 @@ class QMPC:
 
     def send_share(self, secrets: List, schema: List[str],
                    matching_column: int = 1,
-                   party_size: int = 3, piece_size: int = 1_000_000) -> Dict:
+                   piece_size: int = 1_000_000) -> Dict:
         return self.__qmpc_server.send_share(
-            secrets, schema, matching_column,  party_size, piece_size)
+            secrets, schema, matching_column, piece_size)
 
     def delete_share(self, data_ids: List[str]) -> Dict:
         return self.__qmpc_server.delete_share(data_ids)
@@ -112,8 +113,8 @@ class QMPC:
     def get_computation_result(self, job_id: str) -> Dict:
         return self.__qmpc_server.get_computation_result(job_id)
 
-    def send_model_params(self, params: list, party_size: int = 3,) -> Dict:
-        return self.__qmpc_server.send_model_params(params, party_size)
+    def send_model_params(self, params: list) -> Dict:
+        return self.__qmpc_server.send_model_params(params)
 
     def linear_regression_predict(self,
                                   model_param_job_uuid: str,
@@ -155,7 +156,6 @@ class QMPC:
             -> Dict:
         return self.__qmpc_server.get_data_list()
 
-    def demo_sharize(self, secrets: List,
-                     party_size: int = 3) -> Dict:
+    def demo_sharize(self, secrets: List) -> Dict:
         share = Share.sharize(secrets, party_size)
         return {'is_ok': True, 'results': share}

--- a/quickmpc/qmpc.py
+++ b/quickmpc/qmpc.py
@@ -28,6 +28,7 @@ class QMPC:
 
     def __post_init__(self, endpoints: List[str],
                       token: str):
+        object.__setattr__(self, "party_size", len(endpoints))
         object.__setattr__(self, "_QMPC__qmpc_server", QMPCServer(
             endpoints, token))
 
@@ -157,5 +158,5 @@ class QMPC:
         return self.__qmpc_server.get_data_list()
 
     def demo_sharize(self, secrets: List) -> Dict:
-        share = Share.sharize(secrets, party_size)
+        share = Share.sharize(secrets, self.party_size)
         return {'is_ok': True, 'results': share}

--- a/quickmpc/qmpc.py
+++ b/quickmpc/qmpc.py
@@ -25,12 +25,13 @@ class QMPC:
     token: InitVar[str] = "token_demo"
 
     __qmpc_server: QMPCServer = field(init=False)
+    __party_size: int = field(init=False)
 
     def __post_init__(self, endpoints: List[str],
                       token: str):
-        object.__setattr__(self, "party_size", len(endpoints))
         object.__setattr__(self, "_QMPC__qmpc_server", QMPCServer(
             endpoints, token))
+        object.__setattr__(self, "_QMPC__party_size", len(endpoints))
 
     def parse_csv_file(self, filename: str) \
             -> Tuple[List[List[float]], List[str]]:
@@ -158,5 +159,5 @@ class QMPC:
         return self.__qmpc_server.get_data_list()
 
     def demo_sharize(self, secrets: List) -> Dict:
-        share = Share.sharize(secrets, self.party_size)
+        share = Share.sharize(secrets, self.__party_size)
         return {'is_ok': True, 'results': share}

--- a/quickmpc/qmpc_server.py
+++ b/quickmpc/qmpc_server.py
@@ -42,6 +42,7 @@ class QMPCServer:
         stubs = [LibcToManageStub(QMPCServer.__create_grpc_channel(ep))
                  for ep in endpoints]
         object.__setattr__(self, "_QMPCServer__client_stubs", stubs)
+        object.__setattr__(self, "party_size", len(endpoints))
 
     @staticmethod
     def __create_grpc_channel(endpoint: str) -> grpc.Channel:
@@ -101,7 +102,7 @@ class QMPCServer:
         data_id: str = hashlib.sha256(
             str(sorted_secrets).encode() + struct.pack('d', time.time())
         ).hexdigest()
-        shares = [Share.sharize(s, party_size) for s in pieces]
+        shares = [Share.sharize(s, self.party_size) for s in pieces]
         sent_at = str(datetime.datetime.now().strftime('%Y-%m-%d %H:%M:%S'))
 
         # リクエストパラメータを設定して非同期にリクエスト送信
@@ -185,7 +186,7 @@ class QMPCServer:
         """ モデルパラメータをコンテナに送信 """
         # リクエストパラメータを設定
         job_uuid: str = str(uuid.uuid4())
-        params_share: list = Share.sharize(params, party_size)
+        params_share: list = Share.sharize(params, self.party_size)
         reqs = [SendModelParamRequest(job_uuid=job_uuid,
                                       params=json.dumps(param),
                                       token=self.token)

--- a/quickmpc/qmpc_server.py
+++ b/quickmpc/qmpc_server.py
@@ -17,9 +17,8 @@ from .proto.common_types.common_types_pb2 import JobStatus
 from .proto.libc_to_manage_pb2 import (DeleteSharesRequest,
                                        ExecuteComputationRequest,
                                        GetComputationResultRequest,
-                                       GetDataListRequest,
-                                       Input, JoinOrder, PredictRequest,
-                                       SendModelParamRequest,
+                                       GetDataListRequest, Input, JoinOrder,
+                                       PredictRequest, SendModelParamRequest,
                                        SendSharesRequest)
 from .proto.libc_to_manage_pb2_grpc import LibcToManageStub
 from .share import Share
@@ -92,7 +91,7 @@ class QMPCServer:
     @send_share.register(Dim3)
     def __send_share_impl(self, secrets: List, schema: List[str],
                           matching_column: int,
-                          party_size: int, piece_size: int) -> Dict:
+                          piece_size: int) -> Dict:
         """ Shareをコンテナに送信 """
         sorted_secrets = sorted(
             secrets, key=lambda row: row[matching_column-1])
@@ -182,8 +181,7 @@ class QMPCServer:
         results = if_present(results, Share.recons)
         return {"is_ok": is_ok, "statuses": statuses, "results": results}
 
-    def send_model_params(self, params: list,
-                          party_size: int) -> Dict:
+    def send_model_params(self, params: list) -> Dict:
         """ モデルパラメータをコンテナに送信 """
         # リクエストパラメータを設定
         job_uuid: str = str(uuid.uuid4())

--- a/tests/unit_tests/test_qmpc.py
+++ b/tests/unit_tests/test_qmpc.py
@@ -19,7 +19,7 @@ class TestQMPC:
     def test_send_shares(self, secrets, run_server1, run_server2, run_server3):
         """ serverにシェアを送れるかのTest"""
         response: Dict[str, Any] = self.qmpc.send_share(
-            secrets, [], 1, 3, 1000)
+            secrets, [], 1, 1000)
         assert(response["is_ok"])
 
     def test_delete_shares(self, run_server1, run_server2, run_server3):
@@ -45,7 +45,7 @@ class TestQMPC:
     def test_send_model_params(self, run_server1, run_server2, run_server3):
         """ serverにモデルパラメータを送れるかのTest"""
         res: Dict[str, Any] = self.qmpc.send_model_params(
-            [[1, 2, 3]], 3)
+            [[1, 2, 3]])
         assert(res["is_ok"])
 
     def test_predict(self, run_server1, run_server2, run_server3):


### PR DESCRIPTION
# Summary
Modified to set party_size according to the number of endpoints
Fixed party_size as it never changes.

# Purpose
When deploying with two parties, if certain functions (such as send_share) are executed without setting the party_size argument, three shares will be generated by default, but only two will actually be used, and the calculation results may not be normal.

# Contents
Fix to set party_size at class initialization.

# Testing Methods Performed
Send requests to 2- and 3-party QuickMPCs locally
