### PR TITLE
Fix grpcio-tools version

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,7 +5,7 @@ name = "pypi"
 
 [packages]
 numpy = "*"
-grpcio-tools = "*"
+grpcio-tools = "==1.46.3"
 pynacl = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "65d596f74903c4f05c50df2221f95938aa08bb1640fee6c68b0c8e6e50657ee4"
+            "sha256": "34e1300747c9261a8dba6114cfcc356a0cb2ef6b3ccd95bfa23dcc5b21ec3c5d"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -488,7 +488,7 @@
                 "sha256:939de3e7a6161af0c887ef91b7d41a53e7c5a1ca976325f429cb46ea9bc30ecc",
                 "sha256:de526c12914f0c550d15924c62d72abc48d6fe7364aa87328337a31007fe8a4f"
             ],
-            "markers": "python_version < '3.11'",
+            "markers": "python_version >= '3.7'",
             "version": "==2.0.1"
         },
         "tox": {

--- a/setup.cfg
+++ b/setup.cfg
@@ -8,5 +8,5 @@ include_package_data = True
 packages = find:
 install_requires =
 	numpy
-	grpcio-tools
+	grpcio-tools==1.46.3
 	pynacl


### PR DESCRIPTION
# Summary
Fix grpcio-tools version to 1.46.3

# Purpose
Prevent the following errors that appear using grpcio-tools 1.49.0.

```
AttributeError: 'NoneType' object has no attribute 'enum_types_by_name'
```
# Contents
- Fix grpcio-tools version to 1.46.3

# Testing Methods Performed
- run test on Ubuntu20.04, CI