### PR TITLE
Handle CC error info

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -8,6 +8,7 @@ numpy = "*"
 grpcio-tools = "==1.46.3"
 pynacl = "*"
 tqdm = "*"
+grpcio-status = "==1.46.3"
 
 [dev-packages]
 pytest = "*"

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -85,56 +85,72 @@
             ],
             "version": "==1.15.1"
         },
-        "grpcio": {
+        "googleapis-common-protos": {
             "hashes": [
-                "sha256:075f2d06e3db6b48a2157a1bcd52d6cbdca980dd18988fe6afdb41795d51625f",
-                "sha256:08ff74aec8ff457a89b97152d36cb811dcc1d17cd5a92a65933524e363327394",
-                "sha256:0b24a74651438d45619ac67004638856f76cc13d78b7478f2457754cbcb1c8ad",
-                "sha256:0e20d59aafc086b1cc68400463bddda6e41d3e5ed30851d1e2e0f6a2e7e342d3",
-                "sha256:120fecba2ec5d14b5a15d11063b39783fda8dc8d24addd83196acb6582cabd9b",
-                "sha256:17bb6fe72784b630728c6cff9c9d10ccc3b6d04e85da6e0a7b27fb1d135fac62",
-                "sha256:18305d5a082d1593b005a895c10041f833b16788e88b02bb81061f5ebcc465df",
-                "sha256:196082b9c89ebf0961dcd77cb114bed8171964c8e3063b9da2fb33536a6938ed",
-                "sha256:1c66a25afc6c71d357867b341da594a5587db5849b48f4b7d5908d236bb62ede",
-                "sha256:1cc400c8a2173d1c042997d98a9563e12d9bb3fb6ad36b7f355bc77c7663b8af",
-                "sha256:2070e87d95991473244c72d96d13596c751cb35558e11f5df5414981e7ed2492",
-                "sha256:2106d9c16527f0a85e2eea6e6b91a74fc99579c60dd810d8690843ea02bc0f5f",
-                "sha256:221d42c654d2a41fa31323216279c73ed17d92f533bc140a3390cc1bd78bf63c",
-                "sha256:274ffbb39717918c514b35176510ae9be06e1d93121e84d50b350861dcb9a705",
-                "sha256:2f2ff7ba0f8f431f32d4b4bc3a3713426949d3533b08466c4ff1b2b475932ca8",
-                "sha256:34f736bd4d0deae90015c0e383885b431444fe6b6c591dea288173df20603146",
-                "sha256:46d93a1b4572b461a227f1db6b8d35a88952db1c47e5fadcf8b8a2f0e1dd9201",
-                "sha256:49b301740cf5bc8fed4fee4c877570189ae3951432d79fa8e524b09353659811",
-                "sha256:4fcedcab49baaa9db4a2d240ac81f2d57eb0052b1c6a9501b46b8ae912720fbf",
-                "sha256:5207f4eed1b775d264fcfe379d8541e1c43b878f2b63c0698f8f5c56c40f3d68",
-                "sha256:52dd02b7e7868233c571b49bc38ebd347c3bb1ff8907bb0cb74cb5f00c790afc",
-                "sha256:5f8b3a971c7820ea9878f3fd70086240a36aeee15d1b7e9ecbc2743b0e785568",
-                "sha256:64419cb8a5b612cdb1550c2fd4acbb7d4fb263556cf4625f25522337e461509e",
-                "sha256:6b6c3a95d27846f4145d6967899b3ab25fffc6ae99544415e1adcacef84842d2",
-                "sha256:6fd0c9cede9552bf00f8c5791d257d5bf3790d7057b26c59df08be5e7a1e021d",
-                "sha256:822ceec743d42a627e64ea266059a62d214c5a3cdfcd0d7fe2b7a8e4e82527c7",
-                "sha256:8a5272061826e6164f96e3255405ef6f73b88fd3e8bef464c7d061af8585ac62",
-                "sha256:8c9f89c42749890618cd3c2464e1fbf88446e3d2f67f1e334c8e5db2f3272bbd",
-                "sha256:9b449e966ef518ce9c860d21f8afe0b0f055220d95bc710301752ac1db96dd6a",
-                "sha256:9fb17ff8c0d56099ac6ebfa84f670c5a62228d6b5c695cf21c02160c2ac1446b",
-                "sha256:a4f9ba141380abde6c3adc1727f21529137a2552002243fa87c41a07e528245c",
-                "sha256:a7d0017b92d3850abea87c1bdec6ea41104e71c77bca44c3e17f175c6700af62",
-                "sha256:aa34d2ad9f24e47fa9a3172801c676e4037d862247e39030165fe83821a7aafd",
-                "sha256:afbb3475cf7f4f7d380c2ca37ee826e51974f3e2665613996a91d6a58583a534",
-                "sha256:b6a1b39e59ac5a3067794a0e498911cf2e37e4b19ee9e9977dc5e7051714f13f",
-                "sha256:cf0a1fb18a7204b9c44623dfbd1465b363236ce70c7a4ed30402f9f60d8b743b",
-                "sha256:d0d402e158d4e84e49c158cb5204119d55e1baf363ee98d6cb5dce321c3a065d",
-                "sha256:d4725fc9ec8e8822906ae26bb26f5546891aa7fbc3443de970cc556d43a5c99f",
-                "sha256:dc79b2b37d779ac42341ddef40ad5bf0966a64af412c89fc2b062e3ddabb093f",
-                "sha256:e1e83233d4680863a421f3ee4a7a9b80d33cd27ee9ed7593bc93f6128302d3f2",
-                "sha256:ea9d0172445241ad7cb49577314e39d0af2c5267395b3561d7ced5d70458a9f3",
-                "sha256:f1a3b88e3c53c1a6e6bed635ec1bbb92201bb6a1f2db186179f7f3f244829788",
-                "sha256:fa9e6e61391e99708ac87fc3436f6b7b9c6b845dc4639b406e5e61901e1aacde",
-                "sha256:fd86040232e805b8e6378b2348c928490ee595b058ce9aaa27ed8e4b0f172b20",
-                "sha256:fe763781669790dc8b9618e7e677c839c87eae6cf28b655ee1fa69ae04eea03f"
+                "sha256:27a849d6205838fb6cc3c1c21cb9800707a661bb21c6ce7fb13e99eb1f8a0c46",
+                "sha256:a9f4a1d7f6d9809657b7f1316a1aa527f6664891531bcfcc13b6696e685f443c"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==1.49.1"
+            "version": "==1.57.0"
+        },
+        "grpcio": {
+            "hashes": [
+                "sha256:16c2e5d498f292d64146da5623986521a694afd2d0823184c71d917a8d2d63d3",
+                "sha256:19f783b3e164673be26eb1b3b53a40b9ca12b034189e0c15c70561a596035652",
+                "sha256:248c32ee8a0e7d16cfee74d14c8e169e434edbd74b2146a2a96d06200a8f7d03",
+                "sha256:2f39dee8a6516089ab5469ebf03031a6a574508728e38627e5c5c6589a4d46b9",
+                "sha256:32e7d90d02121aab458d1ba5a899ce4639df14b387e3e436eab17d167d23b386",
+                "sha256:3344952c68588d26e877de2e15934437a027526609d0cea698e41151ac4a50cb",
+                "sha256:36a4af2a423688d9a0dd70e5f0a118713446c49ddfebff14547b3418d15c3714",
+                "sha256:39187d5ec73a69bd6ac497aaac59e8c226b6c7c16fc0e00cedf0f83ac1c79daa",
+                "sha256:3ac1c1b63da14172ef2d9a012076d0c6a5885f0fd4fb6f1104f60da6470b9591",
+                "sha256:3b9f67b703d0b8a0ca5308f31b5552a9bf1692060e04b929d2242656c0493dcf",
+                "sha256:3c52aa919c5483179df2612076c9b24608f44277a7978eeeea3014bb31bfae18",
+                "sha256:3d0d7ee2e5bd43175110d323ba9650595707504e5a7d049d6be337df7b4aee77",
+                "sha256:425baff0b0182514b739565d95962b080be134499967c925dbd6aa7a5bc9d82b",
+                "sha256:4bfe3622d2b0406ca867e7558d41a2b7aba312209ab889bfc17ae2d1cd17b6ba",
+                "sha256:4c012b0d4c7c4ba3f832a339330d35975f0181f032ba66f40dd71bd99849b224",
+                "sha256:4de91e690d9179aad372ccecf0d3600f37ad63dd17ae061f521b7baff4e3e1a0",
+                "sha256:63b5d4543bba518ff0c1af3b8031595422a6e243f38d23588b528a08a7851522",
+                "sha256:694e282673dbf178d08c1d0236f22838ec1e2ea1db144f59fe01f9b0514a2f73",
+                "sha256:6f644401f26aae6d012c461eb0ffa3d1c4e4f447a23b061baad9c2e201fe1573",
+                "sha256:748686b1bdd17d5752f35256bb92aacbcb5b6584ad612178a0af4b5301d38f06",
+                "sha256:74aa0a5157fd28037e2e951cb0228a4a7cdcaaac75d8e5650191dfca8e8f9449",
+                "sha256:8a4f4de445aa2ccd99abb3a09d27af38eee75b0d411b28db65aebd46fb6373ca",
+                "sha256:94d2c83590dde9d87ab3ff5f47b293e0c3e908f683ad327f47eb78bb7f7e198d",
+                "sha256:98a4858613f1bc991f79b2dc5d453cf5a8dd95a4fdab8b6daaaff33d8710dd1e",
+                "sha256:a103811a4b318abc9b1592cd6cc9187d34bfb2e192eb0fe113dfabb38a162284",
+                "sha256:a1d9409bc633028f992c05b6b8342dd94b946072fa192c059e626032fb7cc3e0",
+                "sha256:a29913905bc23b0054be96234b8d39fdf3222430c5bf5756a97278ecd49dad0a",
+                "sha256:a9fc58eba09407124edbb17d91e091a296702cef486bd03d50d34e40689c1406",
+                "sha256:bf33ba7e178e75f61f24dd06947599ef04a911d0b384616a4fcb843485f6d92d",
+                "sha256:c0bae51edce0eff1b4a89b57fead01638632ec2baadca3e5b94c730c5baa74e8",
+                "sha256:c15b03b864c046ea3198cbb9be04b8a892216c105d3b5e7a5b7e33bc286aaacb",
+                "sha256:c5157927f98ef9fce6919d3c46330c97e9a179ef1d912458127c71a07372f341",
+                "sha256:ce4a5546f17d68ba0c25ea28edce70c56b354a3cf4e7d78617dec037864d38d5",
+                "sha256:d08475daadc04756d2a20a4bd51fe873b9b4f02fbe11f7bfd8995a7199792c38",
+                "sha256:d1b1418f9d2b7be2fbe3d6e12e19f48a8d24e18597315f01f4df5e019b2d2685",
+                "sha256:d33e17ee64ed77ad9c6deeecf1146e9ee0472b1ca7d37dc4f5ae28fdf6ed8e4e",
+                "sha256:da4e8d1daa741e9165ed9d6f1dba8b94d7d2fc477a43564d4e0b61eac7d5b8e9",
+                "sha256:db22902f085dd4c7979abe3cc415035f4a75a553140c98b751a3ca22d978f2a2",
+                "sha256:e0837ef421af003ba36be10b830e187e8434c9052ef90bfb1a6de1c8586eb5e8",
+                "sha256:e743a40579711c02388b021203f0785f00ac486637fea6ce9f9ab12cbc13ad69",
+                "sha256:ef535dd391e4029834cc1a30a0353ca0d11b21201df570df46e3d6f62323d65a",
+                "sha256:f085e0439129e562c157f85195d8c3f9f538d0d90315d0e41593c47580386f93",
+                "sha256:f5ea8351b4a8713dd2818721c771a2b43c53e229cfc095898779c3aaff6f786e",
+                "sha256:fc5438ea90768017818d54049603e96d5ad0c8b592ec33b2cdc35eaf75582802",
+                "sha256:fe4552c363be5affe5133b9ba66a04e3c1e4f243154666a94fefa357f6352250"
+            ],
+            "markers": "python_version >= '3.7'",
+            "version": "==1.51.0"
+        },
+        "grpcio-status": {
+            "hashes": [
+                "sha256:5357dcd69e51ba3f7b86d57698bd44d2ef295528eb7219b237eb596183334d39",
+                "sha256:78442ac7d2813c56f9cc04f713efd7088596b10f88a4ddd09279211cc48402d5"
+            ],
+            "index": "pypi",
+            "version": "==1.46.3"
         },
         "grpcio-tools": {
             "hashes": [
@@ -287,11 +303,11 @@
         },
         "setuptools": {
             "hashes": [
-                "sha256:1b6bdc6161661409c5f21508763dc63ab20a9ac2f8ba20029aaaa7fdb9118012",
-                "sha256:3050e338e5871e70c72983072fe34f6032ae1cdeeeb67338199c2f74e083a80e"
+                "sha256:6211d2f5eddad8757bd0484923ca7c0a6302ebc4ab32ea5e94357176e0ca0840",
+                "sha256:d1eebf881c6114e51df1664bc2c9133d022f78d12d5f4f665b9191f084e2862d"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==65.4.1"
+            "version": "==65.6.0"
         },
         "six": {
             "hashes": [
@@ -321,11 +337,11 @@
         },
         "autopep8": {
             "hashes": [
-                "sha256:6f09e90a2be784317e84dc1add17ebfc7abe3924239957a37e5040e27d812087",
-                "sha256:ca9b1a83e53a7fad65d731dc7a2a2d50aa48f43850407c59f6a1a306c4201142"
+                "sha256:8b1659c7f003e693199f52caffdc06585bb0716900bbc6a7442fd931d658c077",
+                "sha256:ad924b42c2e27a1ac58e432166cc4588f5b80747de02d0d35b1ecbd3e7d57207"
             ],
             "index": "pypi",
-            "version": "==1.7.0"
+            "version": "==2.0.0"
         },
         "distlib": {
             "hashes": [
@@ -336,11 +352,11 @@
         },
         "exceptiongroup": {
             "hashes": [
-                "sha256:2ac84b496be68464a2da60da518af3785fff8b7ec0d090a581604bc870bdee41",
-                "sha256:affbabf13fb6e98988c38d9c5650e701569fe3c1de3233cfb61c5f33774690ad"
+                "sha256:542adf9dea4055530d6e1279602fa5cb11dab2395fa650b8674eaec35fc4a828",
+                "sha256:bd14967b79cd9bdb54d97323216f8fdf533e278df937aa2a90089e7d6e06e5ec"
             ],
             "markers": "python_version < '3.11'",
-            "version": "==1.0.0"
+            "version": "==1.0.4"
         },
         "filelock": {
             "hashes": [
@@ -391,33 +407,39 @@
         },
         "mypy": {
             "hashes": [
-                "sha256:06e1eac8d99bd404ed8dd34ca29673c4346e76dd8e612ea507763dccd7e13c7a",
-                "sha256:2ee3dbc53d4df7e6e3b1c68ac6a971d3a4fb2852bf10a05fda228721dd44fae1",
-                "sha256:4bc460e43b7785f78862dab78674e62ec3cd523485baecfdf81a555ed29ecfa0",
-                "sha256:64e1f6af81c003f85f0dfed52db632817dabb51b65c0318ffbf5ff51995bbb08",
-                "sha256:6e35d764784b42c3e256848fb8ed1d4292c9fc0098413adb28d84974c095b279",
-                "sha256:6ee196b1d10b8b215e835f438e06965d7a480f6fe016eddbc285f13955cca659",
-                "sha256:756fad8b263b3ba39e4e204ee53042671b660c36c9017412b43af210ddee7b08",
-                "sha256:77f8fcf7b4b3cc0c74fb33ae54a4cd00bb854d65645c48beccf65fa10b17882c",
-                "sha256:794f385653e2b749387a42afb1e14c2135e18daeb027e0d97162e4b7031210f8",
-                "sha256:8ad21d4c9d3673726cf986ea1d0c9fb66905258709550ddf7944c8f885f208be",
-                "sha256:8e8e49aa9cc23aa4c926dc200ce32959d3501c4905147a66ce032f05cb5ecb92",
-                "sha256:9f362470a3480165c4c6151786b5379351b790d56952005be18bdbdd4c7ce0ae",
-                "sha256:a16a0145d6d7d00fbede2da3a3096dcc9ecea091adfa8da48fa6a7b75d35562d",
-                "sha256:ad77c13037d3402fbeffda07d51e3f228ba078d1c7096a73759c9419ea031bf4",
-                "sha256:b6ede64e52257931315826fdbfc6ea878d89a965580d1a65638ef77cb551f56d",
-                "sha256:c9e0efb95ed6ca1654951bd5ec2f3fa91b295d78bf6527e026529d4aaa1e0c30",
-                "sha256:ce65f70b14a21fdac84c294cde75e6dbdabbcff22975335e20827b3b94bdbf49",
-                "sha256:d1debb09043e1f5ee845fa1e96d180e89115b30e47c5d3ce53bc967bab53f62d",
-                "sha256:e178eaffc3c5cd211a87965c8c0df6da91ed7d258b5fc72b8e047c3771317ddb",
-                "sha256:e1acf62a8c4f7c092462c738aa2c2489e275ed386320c10b2e9bff31f6f7e8d6",
-                "sha256:e53773073c864d5f5cec7f3fc72fbbcef65410cde8cc18d4f7242dea60dac52e",
-                "sha256:eb3978b191b9fa0488524bb4ffedf2c573340e8c2b4206fc191d44c7093abfb7",
-                "sha256:f64d2ce043a209a297df322eb4054dfbaa9de9e8738291706eaafda81ab2b362",
-                "sha256:fa38f82f53e1e7beb45557ff167c177802ba7b387ad017eab1663d567017c8ee"
+                "sha256:0714258640194d75677e86c786e80ccf294972cc76885d3ebbb560f11db0003d",
+                "sha256:0c8f3be99e8a8bd403caa8c03be619544bc2c77a7093685dcf308c6b109426c6",
+                "sha256:0cca5adf694af539aeaa6ac633a7afe9bbd760df9d31be55ab780b77ab5ae8bf",
+                "sha256:1c8cd4fb70e8584ca1ed5805cbc7c017a3d1a29fb450621089ffed3e99d1857f",
+                "sha256:1f7d1a520373e2272b10796c3ff721ea1a0712288cafaa95931e66aa15798813",
+                "sha256:209ee89fbb0deed518605edddd234af80506aec932ad28d73c08f1400ef80a33",
+                "sha256:26efb2fcc6b67e4d5a55561f39176821d2adf88f2745ddc72751b7890f3194ad",
+                "sha256:37bd02ebf9d10e05b00d71302d2c2e6ca333e6c2a8584a98c00e038db8121f05",
+                "sha256:3a700330b567114b673cf8ee7388e949f843b356a73b5ab22dd7cff4742a5297",
+                "sha256:3c0165ba8f354a6d9881809ef29f1a9318a236a6d81c690094c5df32107bde06",
+                "sha256:3d80e36b7d7a9259b740be6d8d906221789b0d836201af4234093cae89ced0cd",
+                "sha256:4175593dc25d9da12f7de8de873a33f9b2b8bdb4e827a7cae952e5b1a342e243",
+                "sha256:4307270436fd7694b41f913eb09210faff27ea4979ecbcd849e57d2da2f65305",
+                "sha256:5e80e758243b97b618cdf22004beb09e8a2de1af481382e4d84bc52152d1c476",
+                "sha256:641411733b127c3e0dab94c45af15fea99e4468f99ac88b39efb1ad677da5711",
+                "sha256:652b651d42f155033a1967739788c436491b577b6a44e4c39fb340d0ee7f0d70",
+                "sha256:6d7464bac72a85cb3491c7e92b5b62f3dcccb8af26826257760a552a5e244aa5",
+                "sha256:74e259b5c19f70d35fcc1ad3d56499065c601dfe94ff67ae48b85596b9ec1461",
+                "sha256:7d17e0a9707d0772f4a7b878f04b4fd11f6f5bcb9b3813975a9b13c9332153ab",
+                "sha256:901c2c269c616e6cb0998b33d4adbb4a6af0ac4ce5cd078afd7bc95830e62c1c",
+                "sha256:98e781cd35c0acf33eb0295e8b9c55cdbef64fcb35f6d3aa2186f289bed6e80d",
+                "sha256:a12c56bf73cdab116df96e4ff39610b92a348cc99a1307e1da3c3768bbb5b135",
+                "sha256:ac6e503823143464538efda0e8e356d871557ef60ccd38f8824a4257acc18d93",
+                "sha256:b8472f736a5bfb159a5e36740847808f6f5b659960115ff29c7cecec1741c648",
+                "sha256:b86ce2c1866a748c0f6faca5232059f881cda6dda2a893b9a8373353cfe3715a",
+                "sha256:bc9ec663ed6c8f15f4ae9d3c04c989b744436c16d26580eaa760ae9dd5d662eb",
+                "sha256:c9166b3f81a10cdf9b49f2d594b21b31adadb3d5e9db9b834866c3258b695be3",
+                "sha256:d13674f3fb73805ba0c45eb6c0c3053d218aa1f7abead6e446d474529aafc372",
+                "sha256:de32edc9b0a7e67c2775e574cb061a537660e51210fbf6006b0b36ea695ae9bb",
+                "sha256:e62ebaad93be3ad1a828a11e90f0e76f15449371ffeecca4a0a0b9adc99abcef"
             ],
             "index": "pypi",
-            "version": "==0.981"
+            "version": "==0.991"
         },
         "mypy-extensions": {
             "hashes": [
@@ -436,11 +458,11 @@
         },
         "platformdirs": {
             "hashes": [
-                "sha256:027d8e83a2d7de06bbac4e5ef7e023c02b863d7ea5d079477e722bb41ab25788",
-                "sha256:58c8abb07dcb441e6ee4b11d8df0ac856038f944ab98b7be6b27b2a3c7feef19"
+                "sha256:1006647646d80f16130f052404c6b901e80ee4ed6bef6792e1f238a8969106f7",
+                "sha256:af0276409f9a02373d540bf8480021a048711d572745aef4b7842dad245eba10"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==2.5.2"
+            "version": "==2.5.4"
         },
         "pluggy": {
             "hashes": [
@@ -484,11 +506,11 @@
         },
         "pytest": {
             "hashes": [
-                "sha256:1377bda3466d70b55e3f5cecfa55bb7cfcf219c7964629b967c37cf0bda818b7",
-                "sha256:4f365fec2dff9c1162f834d9f18af1ba13062db0c708bf7b946f8a5c76180c39"
+                "sha256:892f933d339f068883b6fd5a459f03d85bfcb355e4981e146d2c7616c21fef71",
+                "sha256:c4014eb40e10f11f355ad4e3c2fb2c6c6d1919c73f3b5a433de4708202cade59"
             ],
             "index": "pypi",
-            "version": "==7.1.3"
+            "version": "==7.2.0"
         },
         "six": {
             "hashes": [
@@ -516,11 +538,11 @@
         },
         "tox": {
             "hashes": [
-                "sha256:44f3c347c68c2c68799d7d44f1808f9d396fc8a1a500cbc624253375c7ae107e",
-                "sha256:bf037662d7c740d15c9924ba23bb3e587df20598697bb985ac2b49bdc2d847f6"
+                "sha256:b2a920e35a668cc06942ffd1cf3a4fb221a4d909ca72191fb6d84b0b18a7be04",
+                "sha256:f52ca66eae115fcfef0e77ef81fd107133d295c97c52df337adedb8dfac6ab84"
             ],
             "index": "pypi",
-            "version": "==3.26.0"
+            "version": "==3.27.1"
         },
         "typed-ast": {
             "hashes": [
@@ -554,35 +576,35 @@
         },
         "types-protobuf": {
             "hashes": [
-                "sha256:0dad3a5009895c985a56e2837f61902bad9594151265ac0ee907bb16d0b01eb7",
-                "sha256:5082437afe64ce3b31c8db109eae86e02fda11e4d5f9ac59cb8578a8a138aa70"
+                "sha256:97af5ce70d890fdb94cb0c906f5a6624ca2fef58bc04e27990a25509e992a950",
+                "sha256:e9b45008d106e1d10cc77a29d2d344b85c0f01e2e643aaccf32f69e9e81b0cdd"
             ],
             "index": "pypi",
-            "version": "==3.20.4"
+            "version": "==3.20.4.5"
         },
         "types-tabulate": {
             "hashes": [
-                "sha256:17a5fa3b5ca453815778fc9865e8ecd0118b07b2b9faff3e2b06fe448174dd5e",
-                "sha256:af811268241e8fb87b63c052c87d1e329898a93191309d5d42111372232b2e0e"
+                "sha256:4a79474714cea156bcd2185bb9bddd8fb9d3d5227c8d0a7f21bf21caf5f60e67",
+                "sha256:a1cc2aa52d2a9abfe0acbb361ccd49e3400794086a41626ce8784ed2e1ec0b0d"
             ],
             "index": "pypi",
-            "version": "==0.8.11"
+            "version": "==0.9.0.0"
         },
         "types-tqdm": {
             "hashes": [
-                "sha256:0bd113b8084a8f3ea7fa6b49ec8fde5842892f1119844aef549772e5e302db67",
-                "sha256:436b7996d83bac8e539a82ded72e02f0837693c2288d954d30ea610bcf4d1e13"
+                "sha256:24d7c616d40f256e7efb4894b2f10f46c228020cc76bbbe6c549ba8a05e3053e",
+                "sha256:b63406ff848ca80aea65248a303ac8a32d4dea8065ec5fc0f28d66c755ef0fb2"
             ],
             "index": "pypi",
-            "version": "==4.64.7.1"
+            "version": "==4.64.7.3"
         },
         "typing-extensions": {
             "hashes": [
-                "sha256:25642c956049920a5aa49edcdd6ab1e06d7e5d467fc00e0506c44ac86fbfca02",
-                "sha256:e6d2677a32f47fc7eb2795db1dd15c1f34eff616bcaf2cfb5e997f854fa1c4a6"
+                "sha256:1511434bb92bf8dd198c12b1cc812e800d4181cfcb867674e0f8279cc93087aa",
+                "sha256:16fa4864408f655d35ec496218b85f79b3437c829e93320c7c9215ccfd92489e"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==4.3.0"
+            "version": "==4.4.0"
         },
         "virtualenv": {
             "hashes": [
@@ -594,11 +616,11 @@
         },
         "zipp": {
             "hashes": [
-                "sha256:05b45f1ee8f807d0cc928485ca40a07cb491cf092ff587c0df9cb1fd154848d2",
-                "sha256:47c40d7fe183a6f21403a199b3e4192cca5774656965b0a4988ad2f8feb5f009"
+                "sha256:4fcb6f278987a6605757302a6e40e896257570d11c51628968ccb2a47e80c6c1",
+                "sha256:7a7262fd930bd3e36c50b9a64897aec3fafff3dfdeec9623ae22b40e93f99bb8"
             ],
             "markers": "python_version >= '3.7'",
-            "version": "==3.8.1"
+            "version": "==3.10.0"
         }
     }
 }

--- a/quickmpc/__init__.py
+++ b/quickmpc/__init__.py
@@ -1,4 +1,4 @@
-from quickmpc.qmpc import QMPC, JobStatus
+from quickmpc.qmpc import QMPC, JobStatus, JobErrorInfo
 from .version import __version__
 
-__all__ = ["QMPC", "JobStatus", "__version__"]
+__all__ = ["QMPC", "JobStatus", "JobErrorInfo", "__version__"]

--- a/quickmpc/proto/common_types/common_types.proto
+++ b/quickmpc/proto/common_types/common_types.proto
@@ -6,11 +6,12 @@ option go_package = "github.com/acompany-develop/QuickMPC/src/Proto/common_types
 
 enum JobStatus {
     UNKNOWN = 0;
-    PRE_JOB = 1;
-    READ_DB = 2;
-    COMPUTE = 3;
-    WRITE_DB = 4;
-    COMPLETED = 5;
+    ERROR = 1;
+    PRE_JOB = 2;
+    READ_DB = 3;
+    COMPUTE = 4;
+    WRITE_DB = 5;
+    COMPLETED = 6;
 }
 
 enum ComputationMethod {
@@ -46,4 +47,18 @@ message JobProgress {
     string job_uuid = 1;
     JobStatus status = 2;
     repeated ProcedureProgress progresses = 3;
+}
+
+message Stacktrace {
+    message Frame {
+        string source_location = 1;
+        uint64 source_line = 2;
+        string function_name = 3;
+    }
+    repeated Frame frames = 1;
+}
+
+message JobErrorInfo {
+    string what = 1;
+    optional Stacktrace stacktrace = 2;
 }

--- a/quickmpc/proto/common_types/common_types_pb2.py
+++ b/quickmpc/proto/common_types/common_types_pb2.py
@@ -13,7 +13,7 @@ from google.protobuf import symbol_database as _symbol_database
 _sym_db = _symbol_database.Default()
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1f\x63ommon_types/common_types.proto\x12\x0fpb_common_types\"{\n\x11ProcedureProgress\x12\n\n\x02id\x18\x01 \x01(\x04\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x10\n\x08progress\x18\x03 \x01(\x02\x12\x11\n\tcompleted\x18\x04 \x01(\x08\x12\x14\n\x07\x64\x65tails\x18\x05 \x01(\tH\x00\x88\x01\x01\x42\n\n\x08_details\"\x83\x01\n\x0bJobProgress\x12\x10\n\x08job_uuid\x18\x01 \x01(\t\x12*\n\x06status\x18\x02 \x01(\x0e\x32\x1a.pb_common_types.JobStatus\x12\x36\n\nprogresses\x18\x03 \x03(\x0b\x32\".pb_common_types.ProcedureProgress*\\\n\tJobStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\x0b\n\x07PRE_JOB\x10\x01\x12\x0b\n\x07READ_DB\x10\x02\x12\x0b\n\x07\x43OMPUTE\x10\x03\x12\x0c\n\x08WRITE_DB\x10\x04\x12\r\n\tCOMPLETED\x10\x05*\xf1\x02\n\x11\x43omputationMethod\x12\"\n\x1e\x43OMPUTATION_METHOD_UNSPECIFIED\x10\x00\x12\x1b\n\x17\x43OMPUTATION_METHOD_MEAN\x10\x01\x12\x1f\n\x1b\x43OMPUTATION_METHOD_VARIANCE\x10\x02\x12\x1a\n\x16\x43OMPUTATION_METHOD_SUM\x10\x03\x12\x1d\n\x19\x43OMPUTATION_METHOD_CORREL\x10\x04\x12(\n$COMPUTATION_METHOD_LINEAR_REGRESSION\x10\x05\x12*\n&COMPUTATION_METHOD_LOGISTIC_REGRESSION\x10\x06\x12 \n\x1c\x43OMPUTATION_METHOD_MESH_CODE\x10\x07\x12$\n COMPUTATION_METHOD_DECISION_TREE\x10\x08\x12!\n\x1d\x43OMPUTATION_METHOD_JOIN_TABLE\x10\t*\xbd\x01\n\rPredictMethod\x12\x1e\n\x1aPREDICT_METHOD_UNSPECIFIED\x10\x00\x12$\n PREDICT_METHOD_LINEAR_REGRESSION\x10\x01\x12&\n\"PREDICT_METHOD_LOGISTIC_REGRESSION\x10\x02\x12 \n\x1cPREDICT_METHOD_DECISION_TREE\x10\x03\x12\x1c\n\x18PREDICT_METHOD_SID3_TREE\x10\x04\x42=Z;github.com/acompany-develop/QuickMPC/src/Proto/common_typesb\x06proto3')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x1f\x63ommon_types/common_types.proto\x12\x0fpb_common_types\"{\n\x11ProcedureProgress\x12\n\n\x02id\x18\x01 \x01(\x04\x12\x13\n\x0b\x64\x65scription\x18\x02 \x01(\t\x12\x10\n\x08progress\x18\x03 \x01(\x02\x12\x11\n\tcompleted\x18\x04 \x01(\x08\x12\x14\n\x07\x64\x65tails\x18\x05 \x01(\tH\x00\x88\x01\x01\x42\n\n\x08_details\"\x83\x01\n\x0bJobProgress\x12\x10\n\x08job_uuid\x18\x01 \x01(\t\x12*\n\x06status\x18\x02 \x01(\x0e\x32\x1a.pb_common_types.JobStatus\x12\x36\n\nprogresses\x18\x03 \x03(\x0b\x32\".pb_common_types.ProcedureProgress\"\x8d\x01\n\nStacktrace\x12\x31\n\x06\x66rames\x18\x01 \x03(\x0b\x32!.pb_common_types.Stacktrace.Frame\x1aL\n\x05\x46rame\x12\x17\n\x0fsource_location\x18\x01 \x01(\t\x12\x13\n\x0bsource_line\x18\x02 \x01(\x04\x12\x15\n\rfunction_name\x18\x03 \x01(\t\"a\n\x0cJobErrorInfo\x12\x0c\n\x04what\x18\x01 \x01(\t\x12\x34\n\nstacktrace\x18\x02 \x01(\x0b\x32\x1b.pb_common_types.StacktraceH\x00\x88\x01\x01\x42\r\n\x0b_stacktrace*g\n\tJobStatus\x12\x0b\n\x07UNKNOWN\x10\x00\x12\t\n\x05\x45RROR\x10\x01\x12\x0b\n\x07PRE_JOB\x10\x02\x12\x0b\n\x07READ_DB\x10\x03\x12\x0b\n\x07\x43OMPUTE\x10\x04\x12\x0c\n\x08WRITE_DB\x10\x05\x12\r\n\tCOMPLETED\x10\x06*\xf1\x02\n\x11\x43omputationMethod\x12\"\n\x1e\x43OMPUTATION_METHOD_UNSPECIFIED\x10\x00\x12\x1b\n\x17\x43OMPUTATION_METHOD_MEAN\x10\x01\x12\x1f\n\x1b\x43OMPUTATION_METHOD_VARIANCE\x10\x02\x12\x1a\n\x16\x43OMPUTATION_METHOD_SUM\x10\x03\x12\x1d\n\x19\x43OMPUTATION_METHOD_CORREL\x10\x04\x12(\n$COMPUTATION_METHOD_LINEAR_REGRESSION\x10\x05\x12*\n&COMPUTATION_METHOD_LOGISTIC_REGRESSION\x10\x06\x12 \n\x1c\x43OMPUTATION_METHOD_MESH_CODE\x10\x07\x12$\n COMPUTATION_METHOD_DECISION_TREE\x10\x08\x12!\n\x1d\x43OMPUTATION_METHOD_JOIN_TABLE\x10\t*\xbd\x01\n\rPredictMethod\x12\x1e\n\x1aPREDICT_METHOD_UNSPECIFIED\x10\x00\x12$\n PREDICT_METHOD_LINEAR_REGRESSION\x10\x01\x12&\n\"PREDICT_METHOD_LOGISTIC_REGRESSION\x10\x02\x12 \n\x1cPREDICT_METHOD_DECISION_TREE\x10\x03\x12\x1c\n\x18PREDICT_METHOD_SID3_TREE\x10\x04\x42=Z;github.com/acompany-develop/QuickMPC/src/Proto/common_typesb\x06proto3')
 
 _JOBSTATUS = DESCRIPTOR.enum_types_by_name['JobStatus']
 JobStatus = enum_type_wrapper.EnumTypeWrapper(_JOBSTATUS)
@@ -22,11 +22,12 @@ ComputationMethod = enum_type_wrapper.EnumTypeWrapper(_COMPUTATIONMETHOD)
 _PREDICTMETHOD = DESCRIPTOR.enum_types_by_name['PredictMethod']
 PredictMethod = enum_type_wrapper.EnumTypeWrapper(_PREDICTMETHOD)
 UNKNOWN = 0
-PRE_JOB = 1
-READ_DB = 2
-COMPUTE = 3
-WRITE_DB = 4
-COMPLETED = 5
+ERROR = 1
+PRE_JOB = 2
+READ_DB = 3
+COMPUTE = 4
+WRITE_DB = 5
+COMPLETED = 6
 COMPUTATION_METHOD_UNSPECIFIED = 0
 COMPUTATION_METHOD_MEAN = 1
 COMPUTATION_METHOD_VARIANCE = 2
@@ -46,6 +47,9 @@ PREDICT_METHOD_SID3_TREE = 4
 
 _PROCEDUREPROGRESS = DESCRIPTOR.message_types_by_name['ProcedureProgress']
 _JOBPROGRESS = DESCRIPTOR.message_types_by_name['JobProgress']
+_STACKTRACE = DESCRIPTOR.message_types_by_name['Stacktrace']
+_STACKTRACE_FRAME = _STACKTRACE.nested_types_by_name['Frame']
+_JOBERRORINFO = DESCRIPTOR.message_types_by_name['JobErrorInfo']
 ProcedureProgress = _reflection.GeneratedProtocolMessageType('ProcedureProgress', (_message.Message,), {
     'DESCRIPTOR': _PROCEDUREPROGRESS,
     '__module__': 'common_types.common_types_pb2'
@@ -60,18 +64,45 @@ JobProgress = _reflection.GeneratedProtocolMessageType('JobProgress', (_message.
 })
 _sym_db.RegisterMessage(JobProgress)
 
+Stacktrace = _reflection.GeneratedProtocolMessageType('Stacktrace', (_message.Message,), {
+
+    'Frame': _reflection.GeneratedProtocolMessageType('Frame', (_message.Message,), {
+        'DESCRIPTOR': _STACKTRACE_FRAME,
+        '__module__': 'common_types.common_types_pb2'
+        # @@protoc_insertion_point(class_scope:pb_common_types.Stacktrace.Frame)
+    }),
+    'DESCRIPTOR': _STACKTRACE,
+    '__module__': 'common_types.common_types_pb2'
+    # @@protoc_insertion_point(class_scope:pb_common_types.Stacktrace)
+})
+_sym_db.RegisterMessage(Stacktrace)
+_sym_db.RegisterMessage(Stacktrace.Frame)
+
+JobErrorInfo = _reflection.GeneratedProtocolMessageType('JobErrorInfo', (_message.Message,), {
+    'DESCRIPTOR': _JOBERRORINFO,
+    '__module__': 'common_types.common_types_pb2'
+    # @@protoc_insertion_point(class_scope:pb_common_types.JobErrorInfo)
+})
+_sym_db.RegisterMessage(JobErrorInfo)
+
 if _descriptor._USE_C_DESCRIPTORS == False:
 
     DESCRIPTOR._options = None
     DESCRIPTOR._serialized_options = b'Z;github.com/acompany-develop/QuickMPC/src/Proto/common_types'
-    _JOBSTATUS._serialized_start = 311
-    _JOBSTATUS._serialized_end = 403
-    _COMPUTATIONMETHOD._serialized_start = 406
-    _COMPUTATIONMETHOD._serialized_end = 775
-    _PREDICTMETHOD._serialized_start = 778
-    _PREDICTMETHOD._serialized_end = 967
+    _JOBSTATUS._serialized_start = 554
+    _JOBSTATUS._serialized_end = 657
+    _COMPUTATIONMETHOD._serialized_start = 660
+    _COMPUTATIONMETHOD._serialized_end = 1029
+    _PREDICTMETHOD._serialized_start = 1032
+    _PREDICTMETHOD._serialized_end = 1221
     _PROCEDUREPROGRESS._serialized_start = 52
     _PROCEDUREPROGRESS._serialized_end = 175
     _JOBPROGRESS._serialized_start = 178
     _JOBPROGRESS._serialized_end = 309
+    _STACKTRACE._serialized_start = 312
+    _STACKTRACE._serialized_end = 453
+    _STACKTRACE_FRAME._serialized_start = 377
+    _STACKTRACE_FRAME._serialized_end = 453
+    _JOBERRORINFO._serialized_start = 455
+    _JOBERRORINFO._serialized_end = 552
 # @@protoc_insertion_point(module_scope)

--- a/quickmpc/qmpc.py
+++ b/quickmpc/qmpc.py
@@ -18,6 +18,7 @@ ComputationMethod: enum_type_wrapper.EnumTypeWrapper \
     = common_types_pb2.ComputationMethod
 PredictMethod: enum_type_wrapper.EnumTypeWrapper \
     = common_types_pb2.PredictMethod
+JobErrorInfo = common_types_pb2.JobErrorInfo
 
 
 @dataclass(frozen=True)

--- a/quickmpc/qmpc_server.py
+++ b/quickmpc/qmpc_server.py
@@ -14,7 +14,7 @@ from urllib.parse import urlparse
 
 import grpc
 import tqdm  # type: ignore
-from grpc_status import rpc_status
+from grpc_status import rpc_status  # type: ignore
 
 from .proto.common_types.common_types_pb2 import JobStatus, JobErrorInfo
 from .proto.libc_to_manage_pb2 import (DeleteSharesRequest,
@@ -102,7 +102,9 @@ class QMPCServer:
             status = rpc_status.from_call(e)
             if status is not None:
                 for detail in status.details:
-                    if detail.Is(JobErrorInfo.DESCRIPTOR):
+                    if detail.Is(
+                        JobErrorInfo.DESCRIPTOR   # type: ignore[attr-defined]
+                    ):
                         # CC で Job 実行時にエラーが発生していた場合
                         # 例外を rethrow する
                         err_info = JobErrorInfo()

--- a/quickmpc/qmpc_server.py
+++ b/quickmpc/qmpc_server.py
@@ -14,8 +14,9 @@ from urllib.parse import urlparse
 
 import grpc
 import tqdm  # type: ignore
+from grpc_status import rpc_status
 
-from .proto.common_types.common_types_pb2 import JobStatus
+from .proto.common_types.common_types_pb2 import JobStatus, JobErrorInfo
 from .proto.libc_to_manage_pb2 import (DeleteSharesRequest,
                                        ExecuteComputationRequest,
                                        GetComputationResultRequest,
@@ -96,6 +97,24 @@ class QMPCServer:
         except grpc.RpcError as e:
             is_ok = False
             logger.error(f'{e.details()} ({e.code()})')
+
+            # エラーが詳細な情報を持っているか確認
+            status = rpc_status.from_call(e)
+            if status is not None:
+                for detail in status.details:
+                    if detail.Is(JobErrorInfo.DESCRIPTOR):
+                        # CC で Job 実行時にエラーが発生していた場合
+                        # 例外を rethrow する
+                        err_info = JobErrorInfo()
+                        detail.Unpack(err_info)
+                        logger.error(f"job error information: {err_info}")
+
+                        raise e
+
+            # MC で Internal Server Error が発生している場合
+            # 例外を rethrow する
+            if e.code == grpc.UNKHOWN:
+                raise e
         except Exception as e:
             is_ok = False
             logger.error(e)

--- a/quickmpc/qmpc_server.py
+++ b/quickmpc/qmpc_server.py
@@ -115,7 +115,7 @@ class QMPCServer:
 
             # MC で Internal Server Error が発生している場合
             # 例外を rethrow する
-            if e.code == grpc.UNKHOWN:
+            if e.code == grpc.StatusCode.UNKNOWN:
                 raise e
         except Exception as e:
             is_ok = False

--- a/setup.cfg
+++ b/setup.cfg
@@ -10,6 +10,7 @@ python_requires=>=3.7
 install_requires =
     numpy
     grpcio-tools==1.46.3
+    grpcio-status==1.46.3
     pynacl
     tqdm
 include_package_data = True


### PR DESCRIPTION
# Summary

- libClient-py become able to know CC error
- Related PR: https://github.com/acompany-develop/QuickMPC/pull/79

# Purpose

- When an exception was occured in CC,  
  client side could not know such a status.
- This patch will solve this issue partially.

# Contents

- Add `grpcio-status` package
- Get error information via `grpcio-status`
- If error was generated by MC, re-throw exception

# Testing Methods Performed

- Run demo with invalid column index