### PR TITLE
Fix progress bar at demo script

### DIFF
--- a/demo/integration_demo/progress_demo.py
+++ b/demo/integration_demo/progress_demo.py
@@ -130,6 +130,14 @@ if __name__ == '__main__':
                     pbars[key] = (pbar, procedure.progress)
 
         if get_res["results"] is not None:
+            for key in pbars:
+                pbar, prev = pbars[key]
+                if pbar is None:
+                    continue
+                pbar.update(100 - prev)
+                pbar.clear()
+                pbar.close()
+
             break
 
         time.sleep(1)


### PR DESCRIPTION
# Summary

Fix progress bar at demo script

# Purpose

`progress_demo.py` may corrupt displaying progress bar as following,  
this patch will solve this issue.

```console
(demo) dev@host:~/path/to/QuickMPC-libClient-py/demo/integration_demo$ python progress_demo.py 
INFO  | [QuickMPC server IP]=['http://localhost:9001', 'http://localhost:9002', 'http://localhost:9003']
INFO  | parse_csv_data. [data size]=101x10
...
INFO  | job_uuid: feb1aaca-adc4-48aa-be9d-7cbf03932dc5
[0] hjoin: binary search: 100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 100.0/100 [00:02<00:00, 49.28it/s, details=7/7]
...
[2] status: 100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:27<00:00,  4.57s/it, status=COMPLETED]
receive: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 3/3 [00:00<00:00, 1455.34it/s]
INFO  | 27.699000120162964██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 6/6 [00:27<00:00,  5.31s/it, status=COMPLETED]

```

# Contents

- Add explicit `clear` and `close` when a job was finished
- Update progress when a job was finished

# Testing Methods Performed

Run `progress_demo.py` multiple times.